### PR TITLE
changing column header of depth report

### DIFF
--- a/modules/assembly_depth.nf
+++ b/modules/assembly_depth.nf
@@ -18,8 +18,8 @@ process ASSEMBLY_DEPTH {
     depth=\$(echo "scale=2; ${total_bases} / ${assembly_length}" | bc)
 
     #Write header and values to the TSV file
-    echo -e "Sample_id\tRead_type\tDepth" > ${depth_report}
-    echo -e "${sample_id}\t${type}\t\${depth}" >> ${depth_report}    
+    echo -e "Sample_id\t${type}_Depth" > ${depth_report}
+    echo -e "${sample_id}\t\${depth}" >> ${depth_report}    
     """
 }
 
@@ -39,10 +39,10 @@ process COMBINE_DEPTH_REPORTS {
     script:
     """
     # Create header for combined report
-    echo -e "Sample_id\tShort_read_Depth\tLong_read_Depth" > combined_depth_report.tsv
+    echo -e "Sample_id\tshort_Depth\tlong_Depth" > combined_depth_report.tsv
 
-    # Read SR and LR depths and combine into a single line per sample
-    paste <(cut -f1,3 ${sr_depth_reports} | tail -n +2) \
-          <(cut -f3 ${lr_depth_reports} | tail -n +2) >> combined_depth_report.tsv
+    # Combine SR and LR depths into a single line per sample
+    paste <(tail -n +2 ${sr_depth_reports}) \
+          <(cut -f2 ${lr_depth_reports} | tail -n +2) >> combined_depth_report.tsv
     """
 }

--- a/modules/combine_reports.nf
+++ b/modules/combine_reports.nf
@@ -1,6 +1,8 @@
 process COMBINE_REPORTS{
+    
     tag "$sample_id"
     label 'bash_container'
+    label 'process_medium'
     
     publishDir "${params.output}/summary", mode: 'copy', pattern: "*.tsv"
 

--- a/modules/contamination.nf
+++ b/modules/contamination.nf
@@ -1,4 +1,5 @@
 process CHECKM_MARKERS {
+    
     label 'checkm_container'
 
     tag { sample_id }
@@ -19,6 +20,7 @@ process CHECKM_MARKERS {
 }
 
 process CONTAMINATION_CHECKM {
+    
     label 'checkm_container'
     label 'process_medium'
 

--- a/modules/hybrid_assemblers.nf
+++ b/modules/hybrid_assemblers.nf
@@ -1,4 +1,5 @@
 process UNICYCLER{
+    
     label 'unicycler_container'
     label 'process_high'
 

--- a/modules/long_reads_preprocess.nf
+++ b/modules/long_reads_preprocess.nf
@@ -1,4 +1,5 @@
 process CALCULATE_GENOME_SIZE{
+    
     label 'kmc_container'
     label 'process_medium'
 

--- a/modules/quast.nf
+++ b/modules/quast.nf
@@ -1,6 +1,7 @@
 process QUAST {
     
     label 'quast_container'
+    label 'process_medium'
     
     tag "$sample_id"
 

--- a/modules/short_reads_preprocess.nf
+++ b/modules/short_reads_preprocess.nf
@@ -1,7 +1,9 @@
 process CALCULATE_GENOME_SIZE{
+    
     label 'kmc_container'
+    label 'process_medium'
 
-     tag { sample_id }
+    tag {sample_id}
 
     input:
      tuple val(sample_id), path(short_reads1), path(short_reads2), val(genome_size)

--- a/modules/speciation.nf
+++ b/modules/speciation.nf
@@ -1,6 +1,7 @@
 process SPECIATION {
 
     label 'speciation_container'
+    label 'process_medium'
 
     publishDir "${params.output}/speciation_summary", mode: 'copy', pattern: '*.tsv'
 

--- a/modules/validatesamplesheet.nf
+++ b/modules/validatesamplesheet.nf
@@ -1,6 +1,7 @@
 process VALIDATE_SAMPLESHEET {
 
     label 'python_container'
+    label 'process_medium'
 
     input:
     path samplesheet

--- a/workflows/hybrid_assembly.nf
+++ b/workflows/hybrid_assembly.nf
@@ -85,10 +85,10 @@ workflow HY_ASSEMBLY{
     CALCULATEBASES_LR(PORECHOP.out.long_read_assembly)
 
     //calculate short read depth based on assembly length
-    ASSEMBLY_DEPTH_SR (QUAST.out.assembly_length, CALCULATEBASES_SR.out, "short_reads")
+    ASSEMBLY_DEPTH_SR (QUAST.out.assembly_length, CALCULATEBASES_SR.out, "short")
 
     //calculate long read depth based on assembly length
-    ASSEMBLY_DEPTH_LR (QUAST.out.assembly_length, CALCULATEBASES_LR.out, "long_reads")
+    ASSEMBLY_DEPTH_LR (QUAST.out.assembly_length, CALCULATEBASES_LR.out, "long")
 
     //combine SR and LR depth reports
     COMBINE_DEPTH_REPORTS(ASSEMBLY_DEPTH_SR.out, ASSEMBLY_DEPTH_LR.out)

--- a/workflows/lr_assembly.nf
+++ b/workflows/lr_assembly.nf
@@ -61,7 +61,7 @@ workflow LR_ASSEMBLY{
     CALCULATEBASES_LR(preprocessed_long_reads)
 
     //calculate long read depth based on LR assembly length and LR bases
-    ASSEMBLY_DEPTH(QUAST.out.assembly_length,CALCULATEBASES_LR.out, "long_reads")
+    ASSEMBLY_DEPTH(QUAST.out.assembly_length,CALCULATEBASES_LR.out, "long")
 
     //Consolidate all reports
     COMBINE_REPORTS(QUAST.out.report, SPECIATION.out, CONTAMINATION_CHECKM.out, ASSEMBLY_DEPTH.out, "long")

--- a/workflows/sr_assembly.nf
+++ b/workflows/sr_assembly.nf
@@ -67,7 +67,7 @@ workflow SR_ASSEMBLY{
     CALCULATEBASES_SR(processed_short_reads)
 
     //calculate depth of short reads based on assembly length and short read bases
-    ASSEMBLY_DEPTH(QUAST.out.assembly_length,CALCULATEBASES_SR.out, "short_reads")
+    ASSEMBLY_DEPTH(QUAST.out.assembly_length,CALCULATEBASES_SR.out, "short")
 
     //Consolidate all reports
     COMBINE_REPORTS(QUAST.out.report, SPECIATION.out, CONTAMINATION_CHECKM.out, ASSEMBLY_DEPTH.out, "short")


### PR DESCRIPTION
I have changed the column header of the report to include the read name rather than having a separate column for the read type.

`Sample_id	                         short_Depth	   long_Depth`
`nigeria-acinetobacter_bauminnii-02	  59.75       	       230.74`